### PR TITLE
Add extension to ensure that rel="noopener" is added when target="_blank"

### DIFF
--- a/src/storm.umbraco.contrib/Extensions/LinkExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/LinkExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Web;
+
+namespace storm.umbraco.contrib.Extensions
+{
+    public static class LinkExtensions
+    {
+        public static IHtmlString LinkTarget(this string value)
+        {
+            return (!string.IsNullOrEmpty(value) && value == "_blank") ? new HtmlString(@" target=""_blank"" rel=""noopener""") : new HtmlString(string.Empty);
+        }
+    }
+}


### PR DESCRIPTION
Detectify identifies a risk when a link is target="_blank".
A rel="noopener" attribute should be added.

https://support.detectify.com/customer/portal/articles/2792257-external-links-using-target-_blank-