### PR TITLE
Added H1PageTitle extension

### DIFF
--- a/src/storm.umbraco.contrib/Extensions/PublishedContentExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/PublishedContentExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Core.Models;
+using Umbraco.Web;
+
+namespace storm.umbraco.contrib.Extensions
+{
+    public static class PublishedContentExtensions
+    {
+        public static string H1PageTitle(this IPublishedContent content)
+        {
+            var h1PageTitle = content.GetPropertyValue<string>(nameof(H1PageTitle));
+
+            return string.IsNullOrEmpty(h1PageTitle) ? content.Name : h1PageTitle;
+        }
+    }
+}


### PR DESCRIPTION
Display the H1PageTitle if it exists, if not display the node name.

Do we want to allow extensions which reference specific Umbraco property names?