### PR TITLE
Added string truncate method to display extensions

### DIFF
--- a/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
@@ -14,7 +14,7 @@ namespace storm.umbraco.contrib.Extensions
         /// </summary>
         /// <param name="value">The string to be shortened.</param>
         /// <param name="length">The maximum character length, characters after this will be trimmed.</param>
-        /// <param name="keepFullWordAtEnd">Do not split in the middle of a word which goes beyond the character length.</param>
+        /// <param name="keepFullWordAtEnd">Cut from the last whitespace before the character limit.</param>
         /// <param name="ellipsis">A string to be appended at the end of the truncated value.</param>
         /// <returns></returns>
         public static string Truncate(this string value, int length, bool keepFullWordAtEnd = true, string ellipsis = "...")

--- a/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
@@ -9,11 +9,14 @@ namespace storm.umbraco.contrib.Extensions
             return !string.IsNullOrEmpty(value) ? new HtmlString(value.Replace("\n", "<br />")) : new HtmlString(string.Empty);
         }
 
-        /// <param name="value">The string to be trimmed.</param>
-        /// <param name="length">The character length the string will be shortened to.</param>
-        /// <param name="keepFullWordAtEnd">Keep the last full word, even if it goes over the maximum length.</param>
-        /// <param name="ellipsis">An optional additional string which will be appended at the end of the truncated string.</param>
-        /// <returns>The original string shortened to a specific character length.</returns>
+        /// <summary>
+        /// Cuts off a string after a specified character length.
+        /// </summary>
+        /// <param name="value">The string to be shortened.</param>
+        /// <param name="length">The maximum character length, characters after this will be trimmed.</param>
+        /// <param name="keepFullWordAtEnd">Do not split in the middle of a word which goes beyond the character length.</param>
+        /// <param name="ellipsis">A string to be appended at the end of the truncated value.</param>
+        /// <returns></returns>
         public static string Truncate(this string value, int length, bool keepFullWordAtEnd = true, string ellipsis = "...")
         {
             if (string.IsNullOrEmpty(value)) return string.Empty;

--- a/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
@@ -9,6 +9,11 @@ namespace storm.umbraco.contrib.Extensions
             return !string.IsNullOrEmpty(value) ? new HtmlString(value.Replace("\n", "<br />")) : new HtmlString(string.Empty);
         }
 
+        /// <param name="value">The string to be trimmed.</param>
+        /// <param name="length">The character length the string will be shortened to.</param>
+        /// <param name="keepFullWordAtEnd">Keep the last full word, even if it goes over the maximum length.</param>
+        /// <param name="ellipsis">An optional additional string which will be appended at the end of the truncated string.</param>
+        /// <returns>The original string shortened to a specific character length.</returns>
         public static string Truncate(this string value, int length, bool keepFullWordAtEnd = true, string ellipsis = "...")
         {
             if (string.IsNullOrEmpty(value)) return string.Empty;

--- a/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
@@ -8,5 +8,21 @@ namespace storm.umbraco.contrib.Extensions
         {
             return !string.IsNullOrEmpty(value) ? new HtmlString(value.Replace("\n", "<br />")) : new HtmlString(string.Empty);
         }
+
+        public static string Truncate(this string value, int length, string ellipsis, bool keepFullWordAtEnd)
+        {
+            if (string.IsNullOrEmpty(value)) return string.Empty;
+
+            if (value.Length < length) return value;
+
+            value = value.Substring(0, length);
+
+            if (keepFullWordAtEnd)
+            {
+                value = value.Substring(0, value.LastIndexOf(' '));
+            }
+
+            return value + ellipsis;
+        }
     }
 }

--- a/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/DisplayExtensions.cs
@@ -9,7 +9,7 @@ namespace storm.umbraco.contrib.Extensions
             return !string.IsNullOrEmpty(value) ? new HtmlString(value.Replace("\n", "<br />")) : new HtmlString(string.Empty);
         }
 
-        public static string Truncate(this string value, int length, string ellipsis, bool keepFullWordAtEnd)
+        public static string Truncate(this string value, int length, bool keepFullWordAtEnd = true, string ellipsis = "...")
         {
             if (string.IsNullOrEmpty(value)) return string.Empty;
 
@@ -22,7 +22,12 @@ namespace storm.umbraco.contrib.Extensions
                 value = value.Substring(0, value.LastIndexOf(' '));
             }
 
-            return value + ellipsis;
+            if (!string.IsNullOrWhiteSpace(ellipsis))
+            {
+                value += ellipsis;
+            }
+
+            return value;
         }
     }
 }

--- a/tests/contrib.tests/Extensions/TruncateTests.cs
+++ b/tests/contrib.tests/Extensions/TruncateTests.cs
@@ -1,0 +1,48 @@
+﻿using Xunit;
+using storm.umbraco.contrib.Extensions;
+
+namespace contrib.tests.Extensions
+{
+    public class TruncateTests
+    {
+        [Fact]
+        public void Truncate_Length_Only()
+        {
+            const string s = "the quick brown fox jumps over the lazy dog";
+            const string expected = "the quick...";
+
+            string actual = s.Truncate(12);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Truncate_Without_Ellipsis()
+        {
+            const string s = "the quick brown fox jumps over the lazy dog";
+            const string expected = "the quick";
+
+            string actual = s.Truncate(12, ellipsis: null);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Truncate_Do_Not_Keep_Full_Word()
+        {
+            const string s = "the quick brown fox jumps over the lazy dog";
+            const string expected = "the quick br...";
+
+            string actual = s.Truncate(12, keepFullWordAtEnd: false);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Truncate_Do_Not_Keep_Full_Word_And_No_Ellipsis()
+        {
+            const string s = "the quick brown fox jumps over the lazy dog";
+            const string expected = "the quick br";
+
+            string actual = s.Truncate(12, keepFullWordAtEnd: false, ellipsis: null);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/tests/contrib.tests/contrib.tests.csproj
+++ b/tests/contrib.tests/contrib.tests.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\storm.umbraco.contrib\storm.umbraco.contrib.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This will limit a string length to the specified value, with an option to keep the entirety of the last word and add ellipses to show that the text was not finished. 