### PR TITLE
Add WithFallback extension method

### DIFF
--- a/src/storm.umbraco.contrib/Extensions/PropertyExtensions.cs
+++ b/src/storm.umbraco.contrib/Extensions/PropertyExtensions.cs
@@ -7,6 +7,30 @@ namespace storm.umbraco.contrib.Extensions
     public static class PropertyExtensions
     {
         /// <summary>
+        /// A method which attempts to returned a target property if it has a value. If not, a fallback property is returned. If both target and the fallback have no value, then a default value is returned.
+        /// </summary>
+        /// <typeparam name="T">The type of property to be returned.</typeparam>
+        /// <param name="targetProperty">The preferred property to be returned.</param>
+        /// <param name="fallbackProperty">A fallback property to be used if the targetProperty is not set.</param>
+        /// <param name="defaultValue">The default value to be returned if both the target and fallback properties are not set.</param>
+        /// <param name="treatDefaultAsNull">Should default values be returned.</param>
+        /// <returns>The targetProperty if it is set, the highest priority fallback property if it is set, or a default value.</returns>
+        public static T WithFallback<T>(this T targetProperty, T fallbackProperty = default, T defaultValue = default, bool treatDefaultAsNull = false)
+        {
+            if (targetProperty.IsPropertyNotNullOrEmpty(treatDefaultAsNull))
+            {
+                return targetProperty;
+            }
+
+            if (fallbackProperty.IsPropertyNotNullOrEmpty(treatDefaultAsNull))
+            {
+                return fallbackProperty;
+            }
+
+            return EqualityComparer<T>.Default.Equals(defaultValue, default) ? default : defaultValue;
+        }
+
+        /// <summary>
         /// A method which attempts to returned a target property if it has a value. If not, fallback properties are tried in order and the first property with a value is returned. If both target and fallback properties have no value, then a default value is returned.
         /// </summary>
         /// <typeparam name="T">The type of property to be returned.</typeparam>

--- a/tests/contrib.tests/Extensions/WithFallbackTests.cs
+++ b/tests/contrib.tests/Extensions/WithFallbackTests.cs
@@ -1,0 +1,124 @@
+﻿using storm.umbraco.contrib.Extensions;
+using System;
+using Xunit;
+
+namespace Contrib.Tests.Extensions
+{
+    public class WithFallbackTests
+    {
+        [Fact]
+        public void String_Only_TargetProperty_Is_Set()
+        {
+            const string targetProperty = "Here is a sample property";
+            var result = targetProperty.WithFallback();
+            Assert.Equal(targetProperty, result);
+        }
+
+        [Fact]
+        public void String_Only_TargetProperty_Is_Default()
+        {
+            const string targetProperty = default(string);
+            var result = targetProperty.WithFallback();
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void String_TargetProperty_Is_Set_And_One_Fallback_Is_Set()
+        {
+            const string targetProperty = "Here is a sample property";
+            const string fallbackProperty = "Here is a fallback property";
+            var result = targetProperty.WithFallback(fallbackProperty);
+            Assert.Equal(targetProperty, result);
+        }
+
+        [Fact]
+        public void String_TargetProperty_Is_Set_And_One_Fallback_Is_Null()
+        {
+            const string targetProperty = "Here is a sample property";
+            const string fallbackProperty = (string)null;
+            var result = targetProperty.WithFallback(fallbackProperty);
+            Assert.Equal(targetProperty, result);
+        }
+
+        [Fact]
+        public void String_TargetProperty_Is_Null_And_One_Fallback_Is_Set()
+        {
+            const string targetProperty = "";
+            const string fallbackProperty = "Here is a fallback property";
+            var result = targetProperty.WithFallback(fallbackProperty);
+            Assert.Equal(fallbackProperty, result);
+        }
+
+        [Fact]
+        public void Int_TargetProperty_Is_Default_And_One_Fallback_Is_Set()
+        {
+            const int targetProperty = default;
+            const int fallback = 25;
+            var result = targetProperty.WithFallback(fallback);
+            Assert.Equal(targetProperty, result);
+        }
+
+        [Fact]
+        public void Int_TargetProperty_Is_Default_And_One_Fallback_Is_Set_Treat_Default_As_Null()
+        {
+            const int targetProperty = default;
+            const int fallback = 25;
+            var result = targetProperty.WithFallback(fallback, treatDefaultAsNull: true);
+            Assert.Equal(fallback, result);
+        }
+
+        [Fact]
+        public void Double_TargetProperty_Is_Default_And_One_Fallback_Is_Set()
+        {
+            const double targetProperty = default;
+            const double fallback = 24.99;
+            var result = targetProperty.WithFallback(fallback);
+            Assert.Equal(targetProperty, result);
+        }
+
+        [Fact]
+        public void Double_TargetProperty_Is_Default_And_One_Fallback_Is_Set_Treat_Default_As_Null()
+        {
+            const double targetProperty = default;
+            const double fallback = 24.99;
+            var result = targetProperty.WithFallback(fallback, treatDefaultAsNull: true);
+            Assert.Equal(fallback, result);
+        }
+
+        [Fact]
+        public void Boolean_TargetProperty_Is_Default_And_One_Fallback_Is_Set()
+        {
+            const bool targetProperty = default;
+            const bool fallback = true;
+            var result = targetProperty.WithFallback(fallback);
+            Assert.Equal(targetProperty, result);
+        }
+
+        [Fact]
+        public void Boolean_TargetProperty_Is_Default_And_One_Fallback_Is_Set_Set_Treat_Default_As_Null()
+        {
+            const bool targetProperty = default;
+            const bool fallback = true;
+            var result = targetProperty.WithFallback(fallback, treatDefaultAsNull: true);
+            Assert.Equal(fallback, result);
+        }
+
+        [Fact]
+        public void Date_TargetProperty_Is_Default_And_One_Fallback_Is_Set()
+        {
+            var targetProperty = default(DateTime);
+            var fallback = DateTime.Now;
+            var result = targetProperty.WithFallback(fallback, treatDefaultAsNull: true);
+            Assert.Equal(fallback, result);
+        }
+
+        [Fact]
+        public void Date_TargetProperty_Is_Default_And_One_Fallback_Is_Set_Treat_Default_As_Null()
+        {
+            var targetProperty = default(DateTime);
+            var fallback = DateTime.Now;
+            var result = targetProperty.WithFallback(fallback);
+            Assert.Equal(targetProperty, result);
+        }
+    }
+}


### PR DESCRIPTION
Should function exactly the same as the existing `WithFallbacks` method but only takes a single fallback property, so avoids having to create a single item array.